### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/TempSensorADT7410/keywords.txt
+++ b/TempSensorADT7410/keywords.txt
@@ -1,4 +1,4 @@
 TempSensorADT7410	KEYWORD1
 setSensorConfiguration	KEYWORD2
-getCelcius	KEYWORD3
-getFahrenheit	KEYWORD4
+getCelcius	KEYWORD2
+getFahrenheit	KEYWORD2

--- a/TempSensorADT7410/keywords.txt
+++ b/TempSensorADT7410/keywords.txt
@@ -1,4 +1,4 @@
-TempSensorADT7410	 KEYWORD1
-setSensorConfiguration	 KEYWORD2
-getCelcius		 KEYWORD3
-getFahrenheit		 KEYWORD4
+TempSensorADT7410	KEYWORD1
+setSensorConfiguration	KEYWORD2
+getCelcius	KEYWORD3
+getFahrenheit	KEYWORD4


### PR DESCRIPTION
- Remove leading space from keywords.txt identifier token.
- Use correct and valid KEYWORD_TOKENTYPEs.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords